### PR TITLE
Task-21: Created ULID -> UUID conversion bridge for webauthn-rs so we can stay consistent in our use of ULIDs.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,8 @@ src-tauri/*/data/logs/
 .vscode/*
 .kilocode
 .kilocode/*
+
+# Experiments
+# Little snippets to help guide the LLM in how to do very specific and unique things
+experiments
+experiments/*

--- a/documentation/ulid-uuid-conversion.md
+++ b/documentation/ulid-uuid-conversion.md
@@ -1,0 +1,141 @@
+# ULID to UUID Conversion Strategy
+
+## Overview
+
+The Marain CMS project standardizes on ULIDs (Universally Unique Lexicographically Sortable Identifiers) for all entity and user identifiers. However, some external dependencies, particularly the `webauthn-rs` library used for PassKey authentication, require UUIDs. This document describes our conversion strategy to maintain ULID consistency while supporting UUID-dependent libraries.
+
+## The Problem
+
+- **Project Standard**: ULIDs are used throughout the system for their sortability and time-ordering properties
+- **External Dependency**: The `webauthn-rs` library requires UUID v4 for user handles in WebAuthn operations
+- **Solution**: A thin conversion layer that translates between ULIDs and UUIDs without data loss
+
+## Implementation
+
+### Conversion Module
+
+The `ulid_uuid_bridge` module in the `user` crate provides bidirectional conversion functions:
+
+```rust
+// Located at: src-tauri/user/src/ulid_uuid_bridge.rs
+
+/// Convert a ULID to a UUID (byte-for-byte identical)
+pub fn ulid_to_uuid(ulid: &Ulid) -> Uuid
+
+/// Convert a UUID back to a ULID
+pub fn uuid_to_ulid(uuid: &Uuid) -> Ulid
+
+/// Generate a new ULID and return both representations
+pub fn generate_ulid_uuid_pair() -> (Ulid, Uuid)
+
+/// Convert a ULID string to a UUID
+pub fn ulid_string_to_uuid(ulid_str: &str) -> Option<Uuid>
+
+/// Convert a UUID string to a ULID
+pub fn uuid_string_to_ulid(uuid_str: &str) -> Option<Ulid>
+```
+
+### How It Works
+
+Both ULIDs and UUIDs are 128-bit (16-byte) values. The conversion is a straightforward byte-for-byte copy that preserves the underlying value while changing the type:
+
+1. **ULID to UUID**: Extract the 128-bit value from the ULID and create a UUID from it
+2. **UUID to ULID**: Extract the 128-bit value from the UUID and create a ULID from it
+3. **No Data Loss**: The conversion is lossless and reversible
+
+### Usage Example
+
+In the PassKey authentication flow:
+
+```rust
+// When starting PassKey registration
+pub async fn start_registration(
+    &self,
+    db: &UserDatabase,
+    user_id: &str,  // This is a ULID string
+    username: &str,
+) -> Result<(String, CreationChallengeResponse)> {
+    // Convert user's ULID to UUID for webauthn-rs
+    let user_uuid = ulid_string_to_uuid(user_id)
+        .ok_or_else(|| UserError::Configuration(
+            format!("Invalid user ID format: {}", user_id)
+        ))?;
+    
+    // Use the UUID with webauthn-rs
+    let (ccr, reg_state) = self.webauthn
+        .start_passkey_registration(
+            user_uuid,  // webauthn-rs expects UUID
+            username,
+            username,
+            Some(exclude_credentials)
+        )?;
+    
+    // Continue with registration...
+}
+```
+
+## Guidelines for Developers
+
+### When to Use the Conversion Layer
+
+1. **External Libraries**: When calling external libraries that require UUIDs
+2. **API Boundaries**: When interfacing with external systems that expect UUIDs
+3. **Legacy Code**: When integrating with older code that uses UUIDs
+
+### When NOT to Use the Conversion Layer
+
+1. **Internal Code**: All new internal code should use ULIDs directly
+2. **Database Storage**: Always store ULIDs in the database, never UUIDs
+3. **API Responses**: Return ULIDs in API responses unless specifically required otherwise
+
+### Best Practices
+
+1. **Document Usage**: Always add a comment explaining why UUID conversion is needed
+2. **Minimize Scope**: Convert at the boundary, not throughout the codebase
+3. **Validate Input**: Always validate ULID strings before conversion
+4. **Error Handling**: Handle conversion failures gracefully with meaningful error messages
+
+## Database Considerations
+
+The users table and all related tables use TEXT fields that store ULID strings:
+
+```sql
+CREATE TABLE users (
+    id TEXT PRIMARY KEY,  -- Stores ULID as string
+    username TEXT NOT NULL UNIQUE,
+    email TEXT NOT NULL UNIQUE,
+    -- ... other fields
+)
+```
+
+This allows us to:
+- Store ULIDs in their string representation
+- Maintain sortability in database queries
+- Easily identify records by their time-ordered nature
+
+## Future Considerations
+
+If the `webauthn-rs` library or other dependencies eventually support ULIDs natively, we can:
+1. Remove the conversion layer
+2. Update the calling code to pass ULIDs directly
+3. Maintain backward compatibility through the existing database schema
+
+## Testing
+
+The conversion functions are thoroughly tested in `src-tauri/user/src/ulid_uuid_bridge.rs`:
+
+- Round-trip conversion tests ensure no data loss
+- String conversion tests validate parsing
+- Invalid input tests ensure proper error handling
+
+Run tests with:
+```bash
+cd src-tauri && cargo test -p user
+```
+
+## References
+
+- [ULID Specification](https://github.com/ulid/spec)
+- [UUID RFC 4122](https://tools.ietf.org/html/rfc4122)
+- [webauthn-rs Documentation](https://docs.rs/webauthn-rs/)
+- Reference implementation: `experiments/ulid_to_uuid/src/main.rs`

--- a/src-tauri/user/src/lib.rs
+++ b/src-tauri/user/src/lib.rs
@@ -2,6 +2,7 @@ pub mod auth;
 pub mod database;
 pub mod error;
 pub mod secure_log;
+pub mod ulid_uuid_bridge;
 
 #[cfg(test)]
 mod test_secure_log_restart;

--- a/src-tauri/user/src/ulid_uuid_bridge.rs
+++ b/src-tauri/user/src/ulid_uuid_bridge.rs
@@ -1,0 +1,139 @@
+//! ULID to UUID conversion bridge for webauthn-rs compatibility
+//!
+//! This module provides a thin conversion layer between our system's ULIDs
+//! and the UUID requirements of the webauthn-rs library. The conversion is
+//! byte-for-byte identical, preserving the 128-bit value while changing the type.
+
+use ulid::Ulid;
+use uuid::Uuid;
+
+/// Convert a ULID to a UUID for webauthn-rs compatibility
+///
+/// This performs a byte-for-byte conversion from ULID to UUID.
+/// The underlying 128-bit value remains identical.
+///
+/// # Example
+/// ```
+/// use ulid::Ulid;
+/// use user::ulid_uuid_bridge::ulid_to_uuid;
+///
+/// let ulid = Ulid::new();
+/// let uuid = ulid_to_uuid(&ulid);
+/// ```
+pub fn ulid_to_uuid(ulid: &Ulid) -> Uuid {
+    // Convert ULID's u128 representation directly to UUID
+    // This is a straightforward byte-for-byte copy
+    Uuid::from_u128(ulid.0)
+}
+
+/// Convert a UUID back to a ULID
+///
+/// This performs the reverse conversion from UUID to ULID.
+/// Used when retrieving data from webauthn-rs that contains UUIDs.
+///
+/// # Example
+/// ```
+/// use uuid::Uuid;
+/// use user::ulid_uuid_bridge::uuid_to_ulid;
+///
+/// let uuid = Uuid::new_v4();
+/// let ulid = uuid_to_ulid(&uuid);
+/// ```
+pub fn uuid_to_ulid(uuid: &Uuid) -> Ulid {
+    // Convert UUID's 128-bit representation to ULID
+    Ulid::from(uuid.as_u128())
+}
+
+/// Generate a new ULID and return it as both ULID and UUID
+///
+/// This is a convenience function for when you need both representations
+/// of the same identifier, commonly used in PassKey registration.
+///
+/// # Returns
+/// A tuple of (ULID, UUID) representing the same 128-bit value
+pub fn generate_ulid_uuid_pair() -> (Ulid, Uuid) {
+    let ulid = Ulid::new();
+    let uuid = ulid_to_uuid(&ulid);
+    (ulid, uuid)
+}
+
+/// Convert a ULID string to a UUID
+///
+/// Parses a ULID from a string and converts it to UUID.
+/// Returns None if the string is not a valid ULID.
+pub fn ulid_string_to_uuid(ulid_str: &str) -> Option<Uuid> {
+    ulid_str
+        .parse::<Ulid>()
+        .ok()
+        .map(|ulid| ulid_to_uuid(&ulid))
+}
+
+/// Convert a UUID string to a ULID
+///
+/// Parses a UUID from a string and converts it to ULID.
+/// Returns None if the string is not a valid UUID.
+pub fn uuid_string_to_ulid(uuid_str: &str) -> Option<Ulid> {
+    uuid_str
+        .parse::<Uuid>()
+        .ok()
+        .map(|uuid| uuid_to_ulid(&uuid))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_ulid_to_uuid_conversion() {
+        let ulid = Ulid::new();
+        let uuid = ulid_to_uuid(&ulid);
+
+        // Verify the byte representations are identical
+        assert_eq!(ulid.0.to_be_bytes(), *uuid.as_bytes());
+    }
+
+    #[test]
+    fn test_uuid_to_ulid_conversion() {
+        let original_ulid = Ulid::new();
+        let uuid = ulid_to_uuid(&original_ulid);
+        let converted_ulid = uuid_to_ulid(&uuid);
+
+        // Verify round-trip conversion preserves the value
+        assert_eq!(original_ulid, converted_ulid);
+    }
+
+    #[test]
+    fn test_generate_ulid_uuid_pair() {
+        let (ulid, uuid) = generate_ulid_uuid_pair();
+
+        // Verify the pair represents the same value
+        assert_eq!(ulid.0.to_be_bytes(), *uuid.as_bytes());
+
+        // Verify conversion consistency
+        assert_eq!(uuid, ulid_to_uuid(&ulid));
+    }
+
+    #[test]
+    fn test_string_conversions() {
+        let ulid = Ulid::new();
+        let ulid_str = ulid.to_string();
+
+        // Test ULID string to UUID
+        let uuid = ulid_string_to_uuid(&ulid_str);
+        assert!(uuid.is_some());
+        assert_eq!(uuid.unwrap(), ulid_to_uuid(&ulid));
+
+        // Test UUID string to ULID
+        let uuid = ulid_to_uuid(&ulid);
+        let uuid_str = uuid.to_string();
+        let converted_ulid = uuid_string_to_ulid(&uuid_str);
+        assert!(converted_ulid.is_some());
+        assert_eq!(converted_ulid.unwrap(), ulid);
+    }
+
+    #[test]
+    fn test_invalid_string_conversions() {
+        assert!(ulid_string_to_uuid("invalid").is_none());
+        assert!(uuid_string_to_ulid("invalid").is_none());
+    }
+}


### PR DESCRIPTION
This system is documented in `documentation/ulid-uuid-conversion.md` but will likely be moved to the `documentation/user-management-system` as the webauthn-rs crate is the only crate requiring UUIDs so far.